### PR TITLE
bits: Unify BIT macro definition across headers

### DIFF
--- a/include/linux/bits.h
+++ b/include/linux/bits.h
@@ -5,7 +5,7 @@
 #include <linux/const.h>
 #include <asm/bitsperlong.h>
 
-#define BIT(nr)			(UL(1) << (nr))
+#define BIT(nr)			(1UL << (nr))
 #define BIT_ULL(nr)		(ULL(1) << (nr))
 #define BIT_MASK(nr)		(UL(1) << ((nr) % BITS_PER_LONG))
 #define BIT_WORD(nr)		((nr) / BITS_PER_LONG)


### PR DESCRIPTION
The BIT macro in include/linux/bits.h has been updated from:
- #define BIT(nr) (UL(1) << (nr)) to:
- #define BIT(nr) (1UL << (nr))

This change aligns the definition with the existing macro in include/vdso/bits.h to ensure consistency across the codebase. The updated form simplifies the expression by using the standard `1UL` format.